### PR TITLE
Various improvement

### DIFF
--- a/src/components/scm/_filter.vue
+++ b/src/components/scm/_filter.vue
@@ -170,9 +170,9 @@
 import router from '../../router'
 
 import { getApiBaseURL } from '@/composables/api';
-import { isAuthEnabled } from '@/composables/runtime';
+import { isAuthEnabled, getStorageKey } from '@/composables/runtime';
 
-const FILTER_STORAGE_KEY = 'udash.scm.filter.v1';
+const FILTER_STORAGE_KEY = getStorageKey('scm.filter.v1');
 const DEFAULT_DATE_RANGE = [0, 24];
 
 export default {

--- a/src/components/scm/_summary.vue
+++ b/src/components/scm/_summary.vue
@@ -9,21 +9,31 @@
           </v-col>
         </v-row>
         <!-- SCM Cards Layout -->
-        <v-row v-if="!isNoData() && !hideRepositoryTitle" class="mb-2">
+        <v-row v-if="!isNoData()" class="mb-2">
             <v-col cols="12" class="text-right">
                 <v-btn
+                    v-if="!hideRepositoryTitle"
                     size="small"
                     variant="outlined"
+                    class="mr-2"
                     @click="toggleAllRepos"
                 >
                     {{ areAllReposCollapsed() ? 'Show all SCMs' : 'Hide all SCMs' }}
+                </v-btn>
+                <v-btn
+                    v-if="hasEmptyEntries"
+                    size="small"
+                    variant="outlined"
+                    @click="toggleHideEmpty"
+                >
+                    {{ hideEmpty ? 'Show empty' : 'Hide empty' }}
                 </v-btn>
             </v-col>
         </v-row>
 
         <v-row v-if="!isNoData()">
             <v-col
-                v-for="(scmData, url) in data"
+                v-for="(scmData, url) in displayedData"
                 :key="url"
                 cols="12"
                 md="12"
@@ -270,12 +280,12 @@ import router from '../../router'
 import SCMDoughnut from './_scmDoughnut.vue'
 
 import { getApiBaseURL } from '@/composables/api';
-import { isAuthEnabled } from '@/composables/runtime';
+import { isAuthEnabled, getStorageKey } from '@/composables/runtime';
 
 ChartJS.register(RadialLinearScale, ArcElement, Tooltip, Legend)
 
 const EMPTY_DONUT_DATA = Object.freeze({ labels: [], datasets: [] });
-const COLLAPSE_STORAGE_KEY = 'udash:scm-summary-collapse-state';
+const COLLAPSE_STORAGE_KEY = getStorageKey('scm.summary.collapse.v1');
 
 export default {
     components: {
@@ -330,6 +340,7 @@ export default {
         collapsedRepositories: {},
         visibleBranchesByRepo: {},
         initialBranchPageSize: 10,
+        hideEmpty: false,
     }),
 
     computed: {
@@ -351,6 +362,21 @@ export default {
             }
 
             return Math.min(100, Math.round((this.loadedScmBranchCount / this.totalScmCount) * 100));
+        },
+
+        displayedData() {
+            if (!this.hideEmpty) return this.data;
+            return Object.fromEntries(
+                Object.entries(this.data).filter(([, scmData]) =>
+                    Object.values(scmData).some(branch => (Number(branch?.total_result) || 0) > 0)
+                )
+            );
+        },
+
+        hasEmptyEntries() {
+            return Object.values(this.data).some(scmData =>
+                Object.values(scmData).some(branch => (Number(branch?.total_result) || 0) === 0)
+            );
         },
     },
 
@@ -393,6 +419,10 @@ export default {
                     this.collapseAllByDefault = savedState.collapseAllByDefault;
                 }
 
+                if (typeof savedState.hideEmpty === 'boolean') {
+                    this.hideEmpty = savedState.hideEmpty;
+                }
+
                 if (savedState.collapsedRepositories && typeof savedState.collapsedRepositories === 'object' && !Array.isArray(savedState.collapsedRepositories)) {
                     this.collapsedRepositories = Object.fromEntries(
                         Object.entries(savedState.collapsedRepositories).filter(([url, isCollapsed]) => typeof url === 'string' && typeof isCollapsed === 'boolean')
@@ -408,6 +438,7 @@ export default {
                 const stateToPersist = {
                     collapseAllByDefault: this.collapseAllByDefault,
                     collapsedRepositories: this.collapsedRepositories,
+                    hideEmpty: this.hideEmpty,
                     updatedAt: new Date().toISOString(),
                 };
 
@@ -432,11 +463,14 @@ export default {
                 return [];
             }
 
-            return Object.entries(scmData).sort((a, b) => {
+            const entries = Object.entries(scmData).sort((a, b) => {
                 const totalA = Number(a?.[1]?.total_result) || 0;
                 const totalB = Number(b?.[1]?.total_result) || 0;
                 return totalB - totalA;
             });
+
+            if (!this.hideEmpty) return entries;
+            return entries.filter(([, branchData]) => (Number(branchData?.total_result) || 0) > 0);
         },
 
         isRepoCollapsed(url) {
@@ -488,6 +522,11 @@ export default {
             });
 
             this.collapsedRepositories = collapsedRepositories;
+            this.persistCollapseState();
+        },
+
+        toggleHideEmpty() {
+            this.hideEmpty = !this.hideEmpty;
             this.persistCollapseState();
         },
 

--- a/src/composables/api.js
+++ b/src/composables/api.js
@@ -1,10 +1,22 @@
 
 import { getRuntimeConfig } from '@/composables/runtime'
 
-// getApiBaseURL returns the base URL for API requests with no trailing slash
+// getApiBaseURL returns the base URL for API requests with no trailing slash.
 export function getApiBaseURL() {
-    const raw = getRuntimeConfig().API_BASE_URL || '/api'
+  const raw = getRuntimeConfig().API_BASE_URL || '/api'
 
-    // remove any trailing slashes so we can safely append paths like "/pipeline/..."
-    return raw.replace(/\/+$/, '')
+  // remove any trailing slashes so we can safely append paths like "/pipeline/..."
+  return raw.replace(/\/+$/, '')
+}
+
+// getApiBaseUrl returns the fully-qualified API base URL (always includes scheme and domain).
+// Use this when the URL needs to be displayed to or copied by the user.
+export function getApiBaseUrl() {
+  const raw = getApiBaseURL()
+
+  if (raw.startsWith('http://') || raw.startsWith('https://')) {
+    return raw
+  }
+
+  return window.location.origin + raw
 }

--- a/src/composables/runtime.js
+++ b/src/composables/runtime.js
@@ -23,3 +23,7 @@ export function getAppBaseUrl() {
 export function getDashboardUrl() {
   return getAppBaseUrl().replace(/\/$/, '')
 }
+
+export function getStorageKey(id) {
+  return `udash.${id}:${getAppBasePath()}`
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -144,6 +144,7 @@ import ReleaseFooter from '../components/ReleaseFooter.vue';
 import SideNavigation from '../components/SideNavigation.vue';
 import HeadNavigation from '../components/HeadNavigation.vue';
 import { getDashboardUrl } from '@/composables/runtime';
+import { getApiBaseUrl } from '@/composables/api';
 
 export default {
   name: 'HomeView',
@@ -232,7 +233,7 @@ export default {
   }),
   computed: {
     apiBaseUrl() {
-      return window.config?.API_BASE_URL || window.location.origin + "/api"
+      return getApiBaseUrl()
     },
     dashboardUrl() {
       return getDashboardUrl()


### PR DESCRIPTION
* add a new function to have uniq storage cache id
* add helper to get full api url
* use full api url in homepage
* filter to use a uniq per domain storage id
* add button to hide empty

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

Tested manually running `npm run serve` with the following configuration

```
import { defineConfig, loadEnv } from 'vite'
import vue from '@vitejs/plugin-vue'
import { fileURLToPath, URL } from 'node:url'

export default defineConfig(({ mode }) => {
  const env = loadEnv(mode, process.cwd(), '')

  return {
    base: './',
    plugins: [vue()],
    resolve: {
      alias: {
        '@': fileURLToPath(new URL('./src', import.meta.url)),
      },
    },
    server: {
      proxy: {
        '^/api': {
          target: env.VITE_DEV_PROXY_TARGET || 'https://api.uda.sh/updatecli',
          changeOrigin: true,
          ws: true,
          rewrite: (path) => path.replace(/^\/api/, '/'),
        },
      },
    },
  }
})

```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
