### PR TITLE
fix: racing issues with filter

### DIFF
--- a/src/components/scm/_filter.vue
+++ b/src/components/scm/_filter.vue
@@ -270,62 +270,64 @@ export default {
 
     async getSCMSData() {
       this.$emit('loaded', false)
-      const auth_enabled = isAuthEnabled;
+      try {
+        const auth_enabled = isAuthEnabled;
 
-      let query = `${getApiBaseURL()}/pipeline/scms`;
+        let query = `${getApiBaseURL()}/pipeline/scms`;
 
-      if (this.restrictedSCM != "") {
-        query = query + `?scmid=${this.restrictedSCM}`
-      }
+        if (this.restrictedSCM != "") {
+          query = query + `?scmid=${this.restrictedSCM}`
+        }
 
-      if (auth_enabled) {
-        const token = await this.$auth0.getAccessTokenSilently();
+        if (auth_enabled) {
+          const token = await this.$auth0.getAccessTokenSilently();
 
-        const response = await fetch(query, {
+          const response = await fetch(query, {
             headers: {
-            Authorization: `Bearer ${token}`
+              Authorization: `Bearer ${token}`
+            }
+          });
+          const data = await response.json();
+          this.scms = data.scms
+        } else {
+          const response = await fetch(query);
+          const data = await response.json();
+          this.scms = data.scms
+        }
+
+        let urlArray = []
+        this.repositories = []
+        for (var i = 0 ; i < this.scms.length; i++) {
+          if (urlArray.includes(this.scms[i].URL)) {
+            continue
           }
-        });
-        const data = await response.json();
-        this.scms = data.scms
-      } else {
+          urlArray.push(this.scms[i].URL)
 
-        const response = await fetch(query);
-        const data = await response.json();
-        this.scms = data.scms
-      }
-
-      let urlArray = []
-      this.repositories = []
-      for (var i = 0 ; i < this.scms.length; i++) {
-        if (urlArray.includes(this.scms[i].URL)) {
-          continue
-        }
-        urlArray.push(this.scms[i].URL)
-
-        this.repositories.push({
-          id: this.scms[i].URL,
-          text: this.prettifyURL(this.scms[i].URL)
-        })
-      }
-
-      if (this.repositories.length > 0) {
-        const hasStoredRepository = this.repositories.some((item) => item.id === this.repository)
-        if (!hasStoredRepository) {
-          this.repository = this.repositories[0].id
+          this.repositories.push({
+            id: this.scms[i].URL,
+            text: this.prettifyURL(this.scms[i].URL)
+          })
         }
 
-        const repositoryBranches = this.getRepositoryBranches(this.repository)
-        this.branches = repositoryBranches
-        if (!repositoryBranches.includes(this.branch)) {
-          this.branch = repositoryBranches[0] || ''
+        if (this.repositories.length > 0) {
+          const hasStoredRepository = this.repositories.some((item) => item.id === this.repository)
+          if (!hasStoredRepository) {
+            this.repository = this.repositories[0].id
+          }
+
+          const repositoryBranches = this.getRepositoryBranches(this.repository)
+          this.branches = repositoryBranches
+          if (!repositoryBranches.includes(this.branch)) {
+            this.branch = repositoryBranches[0] || ''
+          }
+
+          this.applyFilter()
         }
-
-        this.applyFilter()
+      } catch (error) {
+        console.error('Error fetching SCM data:', error)
+      } finally {
+        this.$emit('loaded', true)
       }
-
-      this.$emit('loaded', true)
-
     },
 
     isRestrictedSCM() {
@@ -825,9 +827,15 @@ export default {
           } else {
             this.getSCMSData()
           }
+          await this.getLabelKeys()
+        } else {
+          // When not showing repository/branch selectors, emit the initial
+          // time-range filter directly so child components get the correct filter.
+          this.$emit('loaded', false)
+          await this.getLabelKeys()
+          this.applyFilter()
+          this.$emit('loaded', true)
         }
-        // Load label keys on component creation
-        await this.getLabelKeys();
     } catch (error) {
       console.log(error);
     }

--- a/src/components/scm/_summary.vue
+++ b/src/components/scm/_summary.vue
@@ -380,6 +380,7 @@ export default {
         hasMoreData: true,
         loadedPages: new Set(),
         isFetching: false,
+        currentRequestId: 0,
         hasSearched: false,
         collapseAllByDefault: true,
         collapsedRepositories: {},
@@ -441,6 +442,8 @@ export default {
         },
 
         resetPagination() {
+            this.currentRequestId += 1;
+            this.isFetching = false;
             this.currentPage = 0;
             this.totalCount = 0;
             this.hasMoreData = true;
@@ -614,13 +617,7 @@ export default {
                 return;
             }
 
-            const next = this.currentPage + 1;
-            await this.getSummaryData(next, false);
-            this.currentPage = next;
-
-            if (this.currentPage >= this.totalCount) {
-                this.hasMoreData = false;
-            }
+            await this.getSummaryData(this.currentPage + 1, false);
         },
 
         async getSummaryData(page= 1 , reset = false) {
@@ -629,6 +626,7 @@ export default {
                 return;
             }
 
+            const requestId = this.currentRequestId;
             this.isFetching = true;
             this.isLoading= true;
             this.$emit('loaded', false)
@@ -698,6 +696,9 @@ export default {
 
                 const responseData = await response.json();
 
+                // Discard stale results if the filter changed while fetching
+                if (requestId !== this.currentRequestId) return;
+
                 // Handle different response structures
                 const scmData = responseData.data || responseData.scms || responseData;
                 const totalCount = responseData.total_count || 0;
@@ -714,22 +715,26 @@ export default {
                     this.data = { ...this.data, ...scmData };
                 }
 
-                // Mark this page as loaded
+                // Mark this page as loaded and advance the page cursor
                 this.loadedPages.add(page);
+                this.currentPage = page;
 
                 // Check if there's more data to load
                 this.hasMoreData = this.countLoadedScmBranches(this.data) < this.totalCount;
 
-                                // Update doughnut chart data only for the newly loaded items
-                                this.updateDoughnutDataForScmData(scmData);
+                // Update doughnut chart data only for the newly loaded items
+                this.updateDoughnutDataForScmData(scmData);
 
             } catch (error) {
-                console.error('Error fetching summary data:', error);
-                // Handle error appropriately
+                if (requestId === this.currentRequestId) {
+                    console.error('Error fetching summary data:', error);
+                }
             } finally {
-                                this.isFetching = false;
-                this.isLoading = false;
-                this.$emit('loaded', true);
+                if (requestId === this.currentRequestId) {
+                    this.isFetching = false;
+                    this.isLoading = false;
+                    this.$emit('loaded', true);
+                }
             }
         },
 

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -57,6 +57,7 @@
             sm="12"
           >
             <PipelineSCMSSummary
+              v-if="isFilterLoaded"
               :filter="filter"
               @loaded="setSummaryLoaded"
             />
@@ -89,6 +90,7 @@ export default {
 
   data: () => ({
     isLoading: true,
+    isFilterLoaded: false,
     filter: {},
     host: window.location.protocol + "//" + window.location.host,
     externalLinks:[
@@ -123,6 +125,7 @@ export default {
       this.filter = newFilter
     },
     setFilterLoaded: function(val) {
+      this.isFilterLoaded = val
       if (!val) this.isLoading = true
     },
     setSummaryLoaded: function(val) {


### PR DESCRIPTION
## Description

Fix racing issues when loading components

src/components/scm/_filter.vue (2 changes):

 - getSCMSData() — wrapped body in try/catch/finally so loaded: true is always emitted even on network errors
 - created() — split into proper if/else: when showRepositoryBranch=false, now emits loaded:false, awaits getLabelKeys(), calls applyFilter() (emitting the time-range filter), then emits loaded:true

src/components/scm/_summary.vue (4 changes):

 - Added currentRequestId: 0 to data()
 - resetPagination() — increments currentRequestId and resets isFetching to false, allowing the next fetch to proceed immediately
 - loadNextPage() — removed stale post-await mutations (currentPage, hasMoreData) which could corrupt state after a filter reset
 - getSummaryData() — captures requestId at start; after the async network gap, discards the response if the request is stale; currentPage is now updated inside the guard; catch/finally are both gated on requestId === this.currentRequestId

src/views/Dashboard.vue (3 changes):

 - Added isFilterLoaded: false to data()
 - setFilterLoaded() — now properly tracks isFilterLoaded
 - PipelineSCMSSummary — added v-if="isFilterLoaded" so it only mounts after the filter has emitted its initial value


<!-- Describe the changes introduced by this pull request -->

## Test

Manually

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
