### PR TITLE
fix: only load activitybar if data

### DIFF
--- a/src/components/pipeline/activityChart.vue
+++ b/src/components/pipeline/activityChart.vue
@@ -257,6 +257,10 @@ export default {
         },
     },
 
+    // loaded carries a status object rather than a nullable summary, so a host can tell
+    // "this instance has never reported" from "the request was refused": the two look
+    // identical from here but call for opposite pages, one onboarding and one not.
+    //   { hasData: Boolean, summary: Object|null, error: String|null }
     emits: ['loaded'],
 
     data: () => ({
@@ -655,18 +659,24 @@ export default {
                 if (requestId !== this.currentRequestId) return;
 
                 this.summary = responseData;
-                this.$emit('loaded', this.hasData ? responseData : null);
+                this.$emit('loaded', {
+                    hasData: this.hasData,
+                    summary: this.hasData ? responseData : null,
+                    error: null,
+                });
             } catch (error) {
                 if (requestId !== this.currentRequestId) return;
 
                 // A summary is still supporting information, so the host keeps rendering
                 // and is told there is no data. The reason is shown in place of the plot
                 // rather than only logged: a blank strip reads as "no activity", which is
-                // the wrong conclusion when the window was simply refused.
+                // the wrong conclusion when the window was simply refused. It travels in
+                // the event too, so a host drawing its own conclusions from an empty
+                // chart can hold them when the window never actually arrived.
                 console.error('fetching pipeline reports summary:', error);
                 this.error = error.message || 'summary unavailable';
                 this.summary = null;
-                this.$emit('loaded', null);
+                this.$emit('loaded', { hasData: false, summary: null, error: this.error });
             } finally {
                 if (requestId === this.currentRequestId) {
                     this.loading = false;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -26,8 +26,12 @@
          nothing until it has reports: an instance that has never reported keeps the
          onboarding page it needs, without a chart of empty days. Gating the section
          rather than its heading is what keeps a signed-out visitor from firing a
-         request the API will refuse. -->
-    <section v-if="isAuthenticated" class="px-6" :class="hasActivity ? 'pt-0 pb-8' : ''">
+         request the API will refuse.
+
+         The section keeps its spacing for as long as the chart is drawing something —
+         a spinner and a refusal both occupy the band — and gives it up only once the
+         summary has confirmed there is nothing to plot. -->
+    <section v-if="isAuthenticated" class="px-6" :class="isKnownEmpty ? '' : 'pt-0 pb-8'">
       <template v-if="hasActivity">
         <h2 class="text-h4 font-weight-bold mb-2">Pipeline activity</h2>
         <p class="text-medium-emphasis mb-6">
@@ -40,9 +44,12 @@
 
     <!-- Get Started Section
 
-         Shown in full only while there is nothing to report yet. Once reports
+         Shown in full only once the summary has come back and confirmed there is
+         nothing to report yet. Telling a busy instance to connect its first runner is
+         the one mistake worth holding the layout back for, so neither this block nor
+         its collapsed form is drawn while the answer is still in flight. Once reports
          are flowing it moves below the feature cards as a collapsed panel. -->
-    <section v-if="isAuthenticated && !hasActivity" class="py-8">
+    <section v-if="isAuthenticated && isKnownEmpty" class="py-8">
       <v-card flat color="background" class="pa-6">
         <v-card-title class="text-h4 font-weight-bold px-0 mb-2">Get Started</v-card-title>
         <p class="text-medium-emphasis mb-8">
@@ -82,8 +89,10 @@
     </section>
 
     <!-- Setup steps, demoted to reference material once this instance is
-         already reporting: at that point they are only needed to add a runner. -->
-    <section v-if="hasActivity" class="pt-0 pb-8 px-6">
+         already reporting: at that point they are only needed to add a runner. A
+         refused summary lands here too — the steps stay reachable, without the page
+         claiming an instance it could not read is a new one. -->
+    <section v-if="showSetupPanel" class="pt-0 pb-8 px-6">
       <v-expansion-panels variant="accordion" flat="true">
         <v-expansion-panel title="Connect another runner">
           <v-expansion-panel-text>
@@ -129,10 +138,11 @@ export default {
     }
   },
   data: () => ({
-    // hasActivity stays false while the summary is loading and whenever it could
-    // not be retrieved, so the page falls back to its onboarding layout instead of
-    // showing a broken widget to a first-time visitor.
-    hasActivity: false,
+    // activity holds the last status ActivityChart reported, and stays null until the
+    // summary settles. Keeping "not known yet" and "the request was refused" apart from
+    // "this instance has never reported" is what the layout below turns on: only the
+    // last of the three is evidence that onboarding is what the viewer needs.
+    activity: null,
 
     features: [
       {
@@ -156,11 +166,27 @@ export default {
     // serve, so lowering MAX_HISTORY_DAYS narrows the chart along with the filter.
     maxHistoryDays() {
       return getMaxHistoryDays()
+    },
+
+    hasActivity() {
+      return this.activity?.hasData === true
+    },
+
+    // isKnownEmpty is the only state the onboarding layout may claim: the summary came
+    // back, and it carried no report at all.
+    isKnownEmpty() {
+      return this.activity !== null && !this.activity.error && !this.activity.hasData
+    },
+
+    // A refused summary leaves activity unknown, so the steps stay available as
+    // reference material rather than as a first-run instruction.
+    showSetupPanel() {
+      return this.hasActivity || Boolean(this.activity?.error)
     }
   },
   methods: {
-    onSummaryLoaded(summary) {
-      this.hasActivity = Boolean(summary)
+    onSummaryLoaded(status) {
+      this.activity = status
     }
   }
 }


### PR DESCRIPTION
## Description

Only load getting started if activitybar ready

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
