### PR TITLE
feat: add token page

### DIFF
--- a/src/components/GetStartedSteps.vue
+++ b/src/components/GetStartedSteps.vue
@@ -4,6 +4,14 @@
       <h3 class="text-h6 mb-2">{{ index + 1 }}. {{ step.title }}</h3>
       <div class="mb-3" v-html="step.description"></div>
 
+      <!-- Both authentication methods need a token, and until now this page asked
+           for one without saying where to get it. -->
+      <p v-if="step.needsToken && isAuthEnabled" class="mb-3 text-medium-emphasis">
+        Both methods use an API token.
+        <router-link class="text-info" to="/profile/tokens">Create one here</router-link>
+        if you have not already — it is shown only once.
+      </p>
+
       <!-- Step with mutually-exclusive methods (Authenticate) -->
       <template v-if="step.methods">
         <v-tabs v-model="authMethod" density="comfortable" class="mb-4">
@@ -54,7 +62,7 @@
 </template>
 
 <script>
-import { getDashboardUrl } from '@/composables/runtime';
+import { getDashboardUrl, isAuthEnabled } from '@/composables/runtime';
 import { getApiBaseUrl } from '@/composables/api';
 
 export default {
@@ -72,16 +80,17 @@ export default {
       {
         title: "Authenticate",
         description: "Connect Updatecli to Udash. Pick the method that fits your environment — you only need one.",
+        needsToken: true,
         methods: [
           {
             label: "Method A – Config file",
-            description: "Stores the token locally — convenient and secure for local development.",
+            description: "Stores the token locally — convenient and secure for local development. Updatecli prompts for the token, or takes it with --token.",
             code: (apiUrl, dashUrl) => `updatecli udash login --experimental --api-url "${apiUrl}" "${dashUrl}"`
           },
           {
             label: "Method B – Environment variables",
             description: "Better for CI/CD pipelines and containers.",
-            code: (apiUrl, dashUrl) => `export UPDATECLI_UDASH_API_URL="${apiUrl}"\nexport UPDATECLI_UDASH_URL="${dashUrl}"\nexport UPDATECLI_UDASH_ACCESS_TOKEN="your_token_here"  # Only if required by your Udash instance`
+            code: (apiUrl, dashUrl) => `export UPDATECLI_UDASH_API_URL="${apiUrl}"\nexport UPDATECLI_UDASH_URL="${dashUrl}"\nexport UPDATECLI_UDASH_ACCESS_TOKEN="udash_pat_..."  # Only if required by your Udash instance`
           }
         ]
       },
@@ -98,6 +107,10 @@ export default {
     },
     dashboardUrl() {
       return getDashboardUrl()
+    },
+    // A module level constant, so it has to be exposed for the template to see it.
+    isAuthEnabled() {
+      return isAuthEnabled
     }
   },
   methods: {

--- a/src/components/HeadNavigation.vue
+++ b/src/components/HeadNavigation.vue
@@ -19,6 +19,7 @@
           </v-avatar>
         </v-list-item>
         <v-list-item prepend-icon="mdi-account" title="Profile" to="/profile" value="profile"></v-list-item>
+        <v-list-item prepend-icon="mdi-key" title="Tokens" to="/profile/tokens" value="tokens"></v-list-item>
         <v-list-item prepend-icon="mdi-logout" title="Logout" value="logout" @click.prevent="logout"></v-list-item>
       </v-list>
     </v-menu>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import HomeView from '../views/HomeView.vue'
 import PipelineReportsView from '../views/pipeline/ReportsView.vue'
 import PipelineReportView from '../views/pipeline/ReportView.vue'
 import ProfileView from "../views/ProfileView.vue";
+import TokensView from "../views/TokensView.vue";
 import Dashboard from "../views/Dashboard.vue";
 import { authGuard } from "@/composables/auth";
 import { getAppBasePath, isAuthEnabled } from '@/composables/runtime'
@@ -38,6 +39,14 @@ if (isAuthEnabled) {
       path: "/profile",
       name: "profile",
       component: ProfileView
+    },
+    // Only registered when auth is enabled: API tokens exist to stand in for a
+    // login, so they mean nothing on an open instance.
+    {
+      beforeEnter: authGuard,
+      path: "/profile/tokens",
+      name: "tokens",
+      component: TokensView
     },
     {
       beforeEnter: authGuard,

--- a/src/views/TokensView.vue
+++ b/src/views/TokensView.vue
@@ -1,0 +1,372 @@
+<template>
+  <v-container class="page-container">
+    <section class="pt-0 pb-8 px-6">
+      <div class="d-flex align-center flex-wrap ga-4 mb-4">
+        <h2 class="text-h5 font-weight-bold d-flex align-center">
+          <v-icon icon="mdi-key" class="mr-2"></v-icon>
+          API tokens
+          <v-tooltip location="right">
+            <template v-slot:activator="{ props }">
+              <v-icon
+                icon="mdi-information-outline"
+                size="small"
+                class="ml-2"
+                v-bind="props"
+              ></v-icon>
+            </template>
+            <span>
+              API tokens let Updatecli publish reports without signing in. Unlike a
+              login session they do not expire, so a pipeline can keep one for as
+              long as it runs unattended.
+            </span>
+          </v-tooltip>
+        </h2>
+
+        <v-spacer></v-spacer>
+
+        <v-btn
+          v-if="canCreate"
+          color="primary"
+          prepend-icon="mdi-plus"
+          @click="openCreateDialog"
+        >
+          New token
+        </v-btn>
+      </div>
+
+      <p class="text-caption text-grey-darken-1 mb-4">
+        Use a token with <code>UPDATECLI_UDASH_ACCESS_TOKEN</code>, or run
+        <code>updatecli udash login</code> and paste it when prompted.
+      </p>
+
+      <!-- The token is shown once and cannot be recovered afterwards, so this has to
+           be impossible to miss and must not disappear on its own. -->
+      <v-alert
+        v-if="createdToken"
+        type="success"
+        variant="tonal"
+        class="mb-6"
+        closable
+        @click:close="createdToken = null"
+      >
+        <div class="font-weight-medium mb-1">Copy your token now</div>
+        <div class="text-body-2 mb-3">
+          This is the only time it is shown. Once you leave this page it cannot be
+          recovered, only replaced.
+        </div>
+        <div class="token-block">
+          <v-btn
+            class="copy-btn"
+            :icon="copied ? 'mdi-check' : 'mdi-content-copy'"
+            size="small"
+            variant="text"
+            aria-label="Copy token"
+            @click="copyToken"
+          ></v-btn>
+          <pre class="overflow-x-auto"><code>{{ createdToken }}</code></pre>
+        </div>
+      </v-alert>
+
+      <v-alert v-if="error" type="error" variant="tonal" density="compact" class="mb-4">
+        {{ error }}
+      </v-alert>
+
+      <v-card variant="flat" class="pa-4 pa-sm-6">
+        <div v-if="loading" class="text-center py-8">
+          <v-progress-circular indeterminate size="48"></v-progress-circular>
+        </div>
+
+        <div v-else-if="tokens.length === 0" class="text-center py-8">
+          <v-icon size="96" color="grey-lighten-2">mdi-key-outline</v-icon>
+          <h3 class="text-h5 mt-6 mb-2 font-weight-medium">No Tokens Yet</h3>
+          <p class="text-body-2 text-grey-darken-1">
+            <template v-if="canCreate">
+              Create one to let Updatecli publish reports from your pipelines.
+            </template>
+            <template v-else>
+              Your account is not allowed to create API tokens. Ask an administrator
+              for the <code>publisher</code> role.
+            </template>
+          </p>
+        </div>
+
+        <v-data-table-virtual
+          v-else
+          :headers="headers"
+          :items="tokens"
+          fixed-header
+          max-height="600px"
+        >
+          <template v-slot:item.scopes="{ item }">
+            <v-chip
+              v-for="scope in item.scopes"
+              :key="scope"
+              size="x-small"
+              class="mr-1"
+              label
+            >
+              {{ scope }}
+            </v-chip>
+          </template>
+
+          <template v-slot:item.created_at="{ item }">
+            {{ toLocalDate(item.created_at) }}
+          </template>
+
+          <template v-slot:item.last_used_at="{ item }">
+            {{ item.last_used_at ? toLocalDate(item.last_used_at) : 'Never' }}
+          </template>
+
+          <template v-slot:item.expires_at="{ item }">
+            {{ item.expires_at ? toLocalDate(item.expires_at) : 'Never' }}
+          </template>
+
+          <template v-slot:item.actions="{ item }">
+            <v-btn
+              icon="mdi-delete"
+              size="small"
+              variant="text"
+              :aria-label="`Revoke ${item.name}`"
+              @click="confirmRevoke(item)"
+            ></v-btn>
+          </template>
+        </v-data-table-virtual>
+      </v-card>
+    </section>
+
+    <!-- Create -->
+    <v-dialog v-model="createDialog" max-width="520">
+      <v-card>
+        <v-card-title>New API token</v-card-title>
+        <v-card-text>
+          <v-text-field
+            v-model="form.name"
+            label="Name"
+            placeholder="ci"
+            hint="What this token is for, so you can recognise it later."
+            persistent-hint
+            variant="outlined"
+            autofocus
+            class="mb-4"
+          ></v-text-field>
+
+          <div class="text-subtitle-2 mb-1">Permissions</div>
+          <v-checkbox
+            v-for="scope in availableScopes"
+            :key="scope.value"
+            v-model="form.scopes"
+            :value="scope.value"
+            :label="scope.label"
+            :hint="scope.hint"
+            persistent-hint
+            density="compact"
+            hide-details="auto"
+          ></v-checkbox>
+
+          <v-alert
+            v-if="createError"
+            type="error"
+            variant="tonal"
+            density="compact"
+            class="mt-4"
+          >
+            {{ createError }}
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn variant="text" @click="createDialog = false">Cancel</v-btn>
+          <v-btn
+            color="primary"
+            :loading="creating"
+            :disabled="!form.name || form.scopes.length === 0"
+            @click="createToken"
+          >
+            Create
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Revoke -->
+    <v-dialog v-model="revokeDialog" max-width="440">
+      <v-card>
+        <v-card-title>Revoke this token?</v-card-title>
+        <v-card-text>
+          Anything still using <strong>{{ revoking?.name }}</strong> stops working
+          immediately. This cannot be undone.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn variant="text" @click="revokeDialog = false">Cancel</v-btn>
+          <v-btn color="error" :loading="revokingBusy" @click="revokeToken">Revoke</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script>
+import { apiFetch } from '@/composables/api';
+import { toLocalDate } from '@/composables/date';
+
+export default {
+  name: 'TokensView',
+  data: () => ({
+    tokens: [],
+    loading: true,
+    error: null,
+
+    permission: '',
+
+    createDialog: false,
+    creating: false,
+    createError: null,
+    createdToken: null,
+    copied: false,
+    form: {
+      name: '',
+      scopes: ['reports:write'],
+    },
+
+    revokeDialog: false,
+    revoking: null,
+    revokingBusy: false,
+
+    headers: [
+      { title: 'Name', key: 'name', align: 'start' },
+      { title: 'Permissions', key: 'scopes', align: 'start', sortable: false },
+      { title: 'Created', key: 'created_at', align: 'start' },
+      { title: 'Last used', key: 'last_used_at', align: 'start' },
+      { title: 'Expires', key: 'expires_at', align: 'start' },
+      { title: '', key: 'actions', align: 'end', width: '64px', sortable: false },
+    ],
+
+    availableScopes: [
+      {
+        value: 'reports:write',
+        label: 'Publish reports',
+        hint: 'What Updatecli needs to send pipeline reports.',
+      },
+      {
+        value: 'reports:read',
+        label: 'Read reports',
+        hint: 'Read access to the reports already published.',
+      },
+    ],
+  }),
+  computed: {
+    // The API is what actually enforces this; hiding the button just avoids
+    // offering an action which is going to be refused.
+    canCreate() {
+      return this.permission === 'publisher' || this.permission === 'admin';
+    },
+  },
+  async created() {
+    await Promise.all([this.getPermission(), this.getTokens()]);
+  },
+  methods: {
+    toLocalDate,
+
+    async getPermission() {
+      try {
+        const data = await apiFetch('/whoami');
+        this.permission = data?.permission || '';
+      } catch (error) {
+        console.error('Error fetching identity:', error);
+      }
+    },
+
+    async getTokens() {
+      this.loading = true;
+      try {
+        const data = await apiFetch('/tokens');
+        this.tokens = data || [];
+        this.error = null;
+      } catch (error) {
+        console.error('Error fetching tokens:', error);
+        this.error = error.message;
+        this.tokens = [];
+      }
+      this.loading = false;
+    },
+
+    openCreateDialog() {
+      this.form = { name: '', scopes: ['reports:write'] };
+      this.createError = null;
+      this.createDialog = true;
+    },
+
+    async createToken() {
+      this.creating = true;
+      try {
+        const data = await apiFetch('/tokens', {
+          method: 'POST',
+          body: { name: this.form.name, scopes: this.form.scopes },
+        });
+        this.createdToken = data.token;
+        this.copied = false;
+        this.createDialog = false;
+        await this.getTokens();
+      } catch (error) {
+        console.error('Error creating token:', error);
+        this.createError = error.message;
+      }
+      this.creating = false;
+    },
+
+    confirmRevoke(token) {
+      this.revoking = token;
+      this.revokeDialog = true;
+    },
+
+    async revokeToken() {
+      this.revokingBusy = true;
+      try {
+        await apiFetch(`/tokens/${this.revoking.id}`, { method: 'DELETE' });
+        this.revokeDialog = false;
+        await this.getTokens();
+      } catch (error) {
+        console.error('Error revoking token:', error);
+        this.error = error.message;
+      }
+      this.revokingBusy = false;
+    },
+
+    copyToken() {
+      if (!navigator.clipboard) {
+        return;
+      }
+      navigator.clipboard.writeText(this.createdToken).then(() => {
+        this.copied = true;
+        setTimeout(() => {
+          this.copied = false;
+        }, 1500);
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+/* Position the copy button in the top-right corner of the token block. */
+.token-block {
+  position: relative;
+  min-width: 0;
+}
+
+.token-block .copy-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+}
+
+/* A token is one long unbreakable string: let it scroll rather than widen the page. */
+.token-block pre {
+  margin: 0;
+  padding: 8px 48px 8px 12px;
+  border-radius: 4px;
+  background: rgba(127, 127, 127, 0.12);
+}
+</style>


### PR DESCRIPTION
## Description

Udash now issues its own long-lived API tokens, because an identity provider access token always expires while an unattended CI pipeline needs a credential it can keep. The frontend is where a user creates one.

This also closes a gap that already existed: `GetStartedSteps.vue` told users to `export UPDATECLI_UDASH_ACCESS_TOKEN="your_token_here"` with **no way to obtain one**.

Nothing here changes how the SPA authenticates. It already uses `oidc-client-ts` with generic `OAUTH_*` runtime config, so it is provider-agnostic as it stands.

Follows the house style confirmed from the existing components: Options API with `setup()` only bridging composables (there is no `<script setup>` anywhere), Vuetify 4, MDI icons.
t
- `v-data-table-virtual` listing name, scopes, created, last used, expires — modelled on `src/components/pipeline/reports.vue`, including its empty-state convention (96px grey icon + `text-h5` heading).
- Create dialog with a name field and scope checkboxes. This is **new ground**: the codebase had no POST-from-a-form precedent, only POST-search.
- One-time reveal in a dismissible `v-alert`, reusing the clipboard pattern from `GetStartedSteps.vue` (`copiedKey` + 1.5s `mdi-check` swap). It does not auto-dismiss, because the token cannot be recovered afterwards.
- Revoke confirmation dialog.
- The **New token** button is hidden unless `GET /whoami` reports `publisher` or `admin`. This is UX only — `POST /api/tokens` is what actually enforces it.

All calls go through the existing `apiFetch(path, { method, body })` in `src/composables/api.js`, which already attaches the bearer. No new HTTP layer.

`/profile/tokens` → `TokensView`, with `beforeEnter: authGuard`.

Registered **only in the `isAuthEnabled` branch**, exactly like `/profile`. The routes array is duplicated across both branches of an `if`, and API tokens are meaningless on an open instance.

`<v-list-item prepend-icon="mdi-key" title="Tokens" to="/profile/tokens">` in the account menu, between Profile and Logout.

A line under the Authenticate step linking to `/profile/tokens`, shown only when auth is enabled.

Two things worth knowing if you touch this:

- The link is a `<router-link>` in the template, **not** an `<a href>` inside the step's `v-html` description. The app uses `createWebHistory`, not hash routing, so a raw anchor would trigger a full page reload and ignore `getAppBasePath()`.
- `isAuthEnabled` is a module-level constant, so it had to be exposed through `computed` for the template to see it under the Options API.

Also updated the sample env var from `your_token_here` to `udash_pat_...`, and noted that `udash login` prompts for the token or takes `--token`.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
